### PR TITLE
Add OHOGEDM to Psychometrics Task View

### DIFF
--- a/Psychometrics.md
+++ b/Psychometrics.md
@@ -623,6 +623,9 @@ repository linked above.
 -   For Bayesian estimation of the (exploratory) DINA (deterministic
     input, noisy and gate) see `r pkg("dina")` and
     `r pkg("edina")`.
+-   `r pkg("ohoegdm")` performs a Bayesian estimation of the
+    ordinal exploratory Higher-order General Diagnostic Model (OHOEGDM) 
+    for Polytomous Data.
 -   Data package containing coded item and q matrices used in various
     psychometric publications: `r pkg("edmdata")`.
 -   `r pkg("BayesLCA")` implements Bayesian LCA.


### PR DESCRIPTION
@pmair78  would it be possible to add a methodology package added in February to CRAN that provides an implementation of ordinal exploratory Higher-order General Diagnostic Model (OHOEGDM) for Polytomous Data: 

https://www.tandfonline.com/doi/full/10.1080/00273171.2021.1985949

/cc @steveculpepper