### PR TITLE
Add packages for potential landscape estimation

### DIFF
--- a/Psychometrics.md
+++ b/Psychometrics.md
@@ -714,6 +714,13 @@ repository linked above.
     methods to process item metadataand use target assessment and
     measurement blueprint constraints to assemble a test form.
 -   `r pkg("heplots")`: Visualizing hypothesis tests in multivariate linear models with hypothesis error plots.
+-   `r pkg("simlandr")` provides tools to estimate generalized
+    potential landscapes from formal psychological models.
+    `r pkg("fitlandr")` provides nonparametric methods to estimate 
+    bivariate vector fields and generalized potential landscapes from 
+    intensive longitudinal data. `r pkg("Isinglandr")` can be used to
+    estimate generalized potential landscapes from Ising networks 
+    generated from the `r pkg("IsingFit")` package.
 
 
 ### Links


### PR DESCRIPTION
The added packages in this commit (`simlandr`, `fitlandr`, and `Isinglandr`) can be used to estimate generalized potential landscapes for psychological data. Generalized potential landscapes can represent the stability of (nonlinear) systems. The added packages are described in the following papers:

Cui, J., Lichtwarck-Aschoff, A., Olthof, M., Li, T., & Hasselman, F. (2023). From metaphor to computation: Constructing the potential landscape for multivariate psychological formal models. Multivariate Behavioral Research, 58(4), 743–761. https://doi.org/10.1080/00273171.2022.2119927
Cui, J., Hasselman, F., & Lichtwarck-Aschoff, A. (2023). Unlocking nonlinear dynamics and multistability from intensive longitudinal data: A novel method. Psychological Methods. https://doi.org/10.1037/met0000623
Cui, J., Lunansky, G., Lichtwarck-Aschoff, A., Mendoza, N., & Hasselman, F. (2023). Quantifying the Stability Landscapes of Psychological Networks. PsyArXiv. https://doi.org/10.31234/osf.io/nd8zc
