### PR TITLE
Add surveyframe to Classical Test Theory section

### DIFF
--- a/Psychometrics.md
+++ b/Psychometrics.md
@@ -463,6 +463,15 @@ repository linked above.
     in CTT and IRT.
 -   The quantifying construct validity procedure is implemented in
     `r pkg("qcv")`.
+-   `r pkg("surveyframe")` supports end-to-end survey research
+    workflows built around a typed instrument object. It covers
+    instrument design with choice sets and branching logic, scale
+    construction, reliability analysis (Cronbach's alpha and McDonald's
+    omega), item-level diagnostics (item-total correlations, floor and
+    ceiling effects), EFA readiness diagnostics (KMO, Bartlett's test,
+    parallel analysis), and CFA/CB-SEM/PLS-SEM model syntax generation
+    for lavaan and seminr without requiring those packages to be
+    installed.
 
 ### Knowledge Structure Analysis:
 


### PR DESCRIPTION
## Package

**surveyframe** (v0.3.0, accepted on CRAN 2026-05-21)

https://CRAN.R-project.org/package=surveyframe

## Proposed section

Classical Test Theory (CTT)

## Justification

surveyframe covers instrument design, scale construction, and CTT-relevant
analysis in a single typed object (the sframe). Specific features that
belong in the CTT section:

- `score_scales()`: scale scoring with reverse coding
- `reliability_report()`: Cronbach's alpha and McDonald's omega via psych
- `item_report()`: item-total correlations, floor and ceiling effect
  proportions, item means and SDs
- `efa_report()`: KMO, Bartlett's test, parallel analysis for EFA readiness
- `cfa_syntax()` / `cfa_lavaan_syntax()` / `sem_lavaan_syntax()` /
  `seminr_syntax()`: model syntax generation for lavaan and seminr without
  requiring those packages as dependencies

The package takes a researcher from instrument design through reliability
and validity analysis in a single reproducible workflow, which aligns with
the CTT workflow of scale development and psychometric evaluation.

## Hard imports

jsonlite, rlang, openssl only. psych, shiny, lavaan, seminr are all
optional/Suggests.